### PR TITLE
Removed repeated code!

### DIFF
--- a/js/retain.js
+++ b/js/retain.js
@@ -7,7 +7,7 @@ $(function(){
             }
         },
         add: function(obj) {
-            var data = JSON.parse(localStorage.notes);
+            var data = this.getAllNotes();
             data.push(obj);
             localStorage.notes = JSON.stringify(data);
         },


### PR DESCRIPTION
We can use `this.getAllNotes();` instead of  `JSON.parse(localStorage.notes);`.